### PR TITLE
Use fully qualified Go module path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
     env:
       - CGO_ENABLED=0
     binary: kroki
+    main: ./cmd/kroki/
     goos:
       - windows
       - darwin

--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,16 @@ Similarly, you can also output to `stdout` when reading from a file using the sp
 
  kroki convert simple.er --out-file -
 
+== Installation
+
+The https://github.com/yuzutech/kroki-cli/releases[releases page] provides binaries for each version to download.
+
+You can also install the package directly from source. The compiled binary will be put into `$GOPATH/bin/` or `$HOME/go/bin/` if `$GOPATH` is not set:
+
+```bash
+go install github.com/yuzutech/kroki-cli/cmd/kroki@latest
+```
+
 == Configuration
 
 To configure the endpoint, you can use a configuration file.

--- a/cmd/kroki/main.go
+++ b/cmd/kroki/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"kroki/cmd"
+	"github.com/yuzutech/kroki-cli/pkg"
 )
 
 var (
@@ -15,5 +15,5 @@ var (
 
 func main() {
 	log.SetFlags(0)
-	cmd.Execute(version, commit)
+	pkg.Execute(version, commit)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module kroki
+module github.com/yuzutech/kroki-cli
 
 go 1.18
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import "github.com/spf13/viper"
 

--- a/pkg/convert.go
+++ b/pkg/convert.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"bufio"

--- a/pkg/convert_test.go
+++ b/pkg/convert_test.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"bytes"

--- a/pkg/decode.go
+++ b/pkg/decode.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"bufio"

--- a/pkg/decode_test.go
+++ b/pkg/decode_test.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"bytes"

--- a/pkg/encode.go
+++ b/pkg/encode.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"bufio"

--- a/pkg/encode_test.go
+++ b/pkg/encode_test.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"bytes"

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"fmt"

--- a/pkg/root.go
+++ b/pkg/root.go
@@ -1,4 +1,4 @@
-package cmd
+package pkg
 
 import (
 	"fmt"


### PR DESCRIPTION
With this change a user can blindly run `go install github.com/yuzutech/kroki-cli/cmd/kroki@latest` to install the package.