### PR TITLE
Update goreleaser config file and add arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       run: |
         curl -sL https://git.io/goreleaser | head -n -2 | bash
         tar -xf /tmp/goreleaser.tar.gz -C $(go env GOPATH)/bin
-        goreleaser --snapshot --skip-sign
+        goreleaser --snapshot --skip=sign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,6 @@ jobs:
         run: |
           curl -sL https://git.io/goreleaser | head -n -2 | bash
           tar -xf /tmp/goreleaser.tar.gz -C $(go env GOPATH)/bin
-          goreleaser --skip-sign
+          goreleaser --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: kroki-cli
 
 before:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ archives:
   -
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 
 release:
   github:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       - openbsd
     goarch:
       - amd64
+      - arm64
 
 archives:
   -


### PR DESCRIPTION
Fixes #40

Along the way I found that the `.goreleaser.yml` config file was out of date. This fixes that (see commit history for details).

## How this was tested

- `goreleaser check` to check the config file
- `goreleaser release --snapshot --clean` and run `./kroki-cli/dist/kroki-cli_darwin_arm64_v8.0/kroki --help` (which worked)
