### PR TITLE
Update README with Pixi install instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ You can also install using https://pixi.prefix.dev/latest/installation/[Pixi]:
 pixi global install --channel https://prefix.dev/github-releases kroki-cli
 ----
 
-You can also install the package directly from source. The compiled binary will be put into `$GOPATH/bin/` or `$HOME/go/bin/` if `$GOPATH` is not set:
+Alternatively, you can install the package directly from source. The compiled binary will be put into `$GOPATH/bin/` or `$HOME/go/bin/` if `$GOPATH` is not set:
 
 ```bash
 go install github.com/yuzutech/kroki-cli/cmd/kroki@latest

--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,13 @@ Similarly, you can also output to `stdout` when reading from a file using the sp
 
 The https://github.com/yuzutech/kroki-cli/releases[releases page] provides binaries for each version to download.
 
+You can also install using https://pixi.prefix.dev/latest/installation/[Pixi]:
+
+[source,bash]
+----
+pixi global install --channel https://prefix.dev/github-releases kroki-cli
+----
+
 You can also install the package directly from source. The compiled binary will be put into `$GOPATH/bin/` or `$HOME/go/bin/` if `$GOPATH` is not set:
 
 ```bash


### PR DESCRIPTION
in Xarray we're considering using Kroki as part of our development workflow https://github.com/pydata/xarray/issues/11214 .

We (and a lot of other projects) use [Pixi](https://pixi.prefix.dev/latest/) to manage our dependencies. Pixi can also be used to install Kroki either on the project level, or globally for the system. I think adding instructions here for installing Kroki via Pixi would be very useful for both projects as well as users alike.

This PR shows how you can install Kroki globally using Pixi.

_Disclaimer: I am a big Pixi fan - but not a core dev/maintainer. Feel free to reject this (opinionated) PR - I just find this extremely useful._